### PR TITLE
More tag options and a fix for feed titles that with unescaped ampersands

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+#### August 30, 2009
+
+* Added fix for feeds with ampersand in the title
+* Fixed type in tag docs
+* Added feed:if_longer_than tag for better customization of post truncation
+* Added feed:time_elapsed for friendly display of post age
+* Fixed miscalculation of post length due to inline HTML
+* Fixed empty post bug
+
 #### September 15, 2008
 
 * use URI#request_uri to include URI parameters

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+#### March 29, 2012
+
+* Added support for unescaping html in feed content
+* Added support for more RSS syntaxes
+
 #### August 30, 2009
 
 * Added fix for feeds with ampersand in the title

--- a/README.markdown
+++ b/README.markdown
@@ -10,11 +10,13 @@ If-Modified-Since HTTP header).
 
 ## via Git
 
+    gem install htmlentities
     cd RADIANT_APP_ROOT
     git clone git://github.com/lorenjohnson/radiant-rss-reader.git vendor/extensions/rss_reader
 
 ## via Git (as submodule)
   
+    gem install htmlentities
     cd RADIANT_APP_ROOT
     git submodule add git://github.com/lorenjohnson/radiant-rss-reader.git vendor/extensions/rss_reader
 
@@ -24,6 +26,7 @@ If-Modified-Since HTTP header).
 
 Download the tarball from http://github.com/lorenjohnson/radiant-rss-reader/tarball/master into `RADIANT_APP_ROOT/vendor/extentions`, then:
 
+    gem install htmlentities
     cd RADIANT_APP_ROOT/vendor/extentions
     tar xvzf lorenjohnson-radiant-rss-reader.tgz
     mv lorenjohnson-radiant-rss-reader rss_reader

--- a/lib/feedparser/feedparser.rb
+++ b/lib/feedparser/feedparser.rb
@@ -173,12 +173,14 @@ module FeedParser
       end
       # Content
       if (e = item.elements['content:encoded']) ||
-        (e = item.elements['description'] || item.elements['rss:description'])
+        (e = item.elements['description'] || item.elements['rss:description']) ||
+        (e = item.elements['content'])
         @content = FeedParser::getcontent(e, @feed)
       end
       # Date
       if e = item.elements['dc:date'] || item.elements['pubDate'] || 
-          item.elements['rss:pubDate']
+          item.elements['rss:pubDate'] || item.elements['published'] ||
+          item.elements['updated']
         begin
           @date = Time::xmlschema(e.text)
         rescue

--- a/lib/rss_reader.rb
+++ b/lib/rss_reader.rb
@@ -59,7 +59,7 @@ module RssReader
     
     *Usage:*
 
-    <pre><code><r:find:items url="http://somefeed.com/rss" [cache_time="3600"] [order="creator date desc"] [limit="5"]>...</r:feed:items></code></pre>
+    <pre><code><r:feed:items url="http://somefeed.com/rss" [cache_time="3600"] [order="creator date desc"] [limit="5"]>...</r:feed:items></code></pre>
     }
     tag "feed:items" do |tag|
       attr = tag.attr.symbolize_keys

--- a/lib/rss_reader.rb
+++ b/lib/rss_reader.rb
@@ -143,16 +143,18 @@ module RssReader
     tag "feed:content" do |tag|
       attr = tag.attr.symbolize_keys
       result = tag.locals.item.content
-      if attr[:max_length]
-        l = tag.locals.item.content.size()
-      	maxl = attr[:max_length].to_i
-      	if l > maxl
-      	  result = tag.locals.item.content[0..maxl] + ' ...'
-      	end
-      end
       if result
         result = result.gsub(/\A<p>(.*)<\/p>\z/m,'\1') if attr[:no_p]
         result = result.gsub(/<[^>]+>/, '') if attr[:no_html]
+      end
+      result.strip!
+      result.gsub!(/\s+/, ' ')
+      if attr[:max_length]
+        l = result.size
+      	maxl = attr[:max_length].to_i
+      	if l > maxl
+      	  result = result[0..maxl]
+      	end
       end
       result
     end

--- a/lib/rss_reader.rb
+++ b/lib/rss_reader.rb
@@ -5,6 +5,7 @@ require 'feedparser/feedparser'
 
 module RssReader
   include Radiant::Taggable
+  include ActionView::Helpers::DateHelper
   
   def fetch_rss(uri, cache_time)
     c = File.join(ActionController::Base.page_cache_directory, uri.tr(':/','_'))
@@ -176,6 +177,31 @@ module RssReader
         date.strftime(format)
       end
     end
+
+  desc %{
+    Display the time elapsed since the item was posted in a friendly format
+
+    Optional attributes:
+
+    * @use_timestamp_after@: This specifies how many days must elapse before a timestamp
+        is displayed instead of elapsed time. It defaults to 10 days. Specify 0 to never use a timestamp.
+    * @format@: Timestamp format to use if @use_timestamp_after@ is specified. Default is "%A, %B %d, %Y".
+
+    *Usage:*
+
+    <pre><code><r:feed:time_elapsed [format="%b %d"]/></code></pre>
+  }
+  tag "feed:time_elapsed" do |tag|
+    format = (tag.attr['format'] || '%d %b %Y')
+    num_days = tag.attr['use_timestamp_after'].blank? ? 10 : tag.attr['use_timestamp_after'].to_i
+    from_time = tag.locals.item.date.to_time
+    to_time = Time.now
+    if num_days != 0 && (to_time - from_time).round > num_days.days.to_i
+      from_time.strftime(format)
+    else
+    time_ago_in_words(from_time, to_time) + " ago"
+    end
+  end
 
  desc %{
     Display the creator of the rss feed item

--- a/lib/rss_reader.rb
+++ b/lib/rss_reader.rb
@@ -142,7 +142,7 @@ module RssReader
 
     tag "feed:content" do |tag|
       attr = tag.attr.symbolize_keys
-      result = tag.locals.item.content
+      result = tag.locals.item.content || ""
       if result
         result = result.gsub(/\A<p>(.*)<\/p>\z/m,'\1') if attr[:no_p]
         result = result.gsub(/<[^>]+>/, '') if attr[:no_html]

--- a/lib/rss_reader.rb
+++ b/lib/rss_reader.rb
@@ -275,6 +275,7 @@ module RssReader
     num_days = tag.attr['use_timestamp_after'].blank? ? 10 : tag.attr['use_timestamp_after'].to_i
     from_time = tag.locals.item.date.to_time
     to_time = Time.now
+    to_time = Time.now.utc if from_time.utc?
     if num_days != 0 && (to_time - from_time).round > num_days.days.to_i
       from_time.strftime(format)
     else

--- a/lib/rss_reader.rb
+++ b/lib/rss_reader.rb
@@ -12,7 +12,6 @@ module RssReader
     c = File.join(ActionController::Base.page_cache_directory, uri.tr(':/','_'))
     if (cached_feed = feed_for(IO.read(c)) rescue nil)
       if File.mtime(c) > (Time.now - cache_time)
-        logger.info "Returning cached feed"
         return cached_feed 
       end
       since = File.mtime(c).httpdate
@@ -26,7 +25,6 @@ module RssReader
       answer = http.get("#{u.request_uri}", {"If-Modified-Since" => since, 'User-Agent' => 'RadiantCMS rss_reader Extension 0.1'} )
       feed = feed_for(answer.body)
     rescue
-      logger.info "Returning cached feed"
       return cached_feed
     end
     case answer.code

--- a/lib/rss_reader.rb
+++ b/lib/rss_reader.rb
@@ -111,7 +111,7 @@ module RssReader
     end
     
     tag "feed:title" do |tag|
-      tag.locals.item.title
+      tag.locals.item.title.gsub(/(&(amp;)?)/, '&amp;')
     end
 
     tag "feed:link" do |tag|
@@ -119,7 +119,7 @@ module RssReader
       attributes = options.inject('') { |s, (k, v)| s << %{#{k.downcase}="#{v}" } }.strip
       attributes = " #{attributes}" unless attributes.empty?
       href = tag.locals.item.link
-      text = tag.double? ? tag.expand : tag.locals.item.title
+      text = tag.double? ? tag.expand : tag.locals.item.title.gsub(/(&(amp;)?)/, '&amp;')
       %{<a href="#{href}"#{attributes}>#{text}</a>}
     end
     

--- a/lib/rss_reader.rb
+++ b/lib/rss_reader.rb
@@ -213,6 +213,32 @@ module RssReader
     tag "feed:creator" do |tag|
       tag.locals.item.creator
     end
+    
+  desc %{
+    Determine if feed content exceeds a certain length.
 
+    Optional attributes:
+    * @ignore_html@:    determines length after removing html and surrounding whitespace
+
+    *Usage:*
+
+    <pre><code>
+    <r:feed:if_longer_than length="160">
+      ... (<a href="<r:feed:uri />">More</a>)
+    </r:feed:if_longer_than>
+    </code></pre>
+  }
+  tag "feed:if_longer_than" do |tag|
+    attr = tag.attr.symbolize_keys
+    not_to_exceed = attr[:length].to_i
+    content = tag.locals.item.content || ""
+    if attr[:ignore_html]
+      content.gsub!(/<[^>]+>/, '')
+      content.gsub!(/\s+/, '')
+      content.strip!
+    end
+    if content.length > not_to_exceed
+      tag.expand
+    end
+  end
 end
-  


### PR DESCRIPTION
Hey Loren, I've been sitting on these modifications for a while, but it just occurred to me that they might be useful to you. There is a fix in there for feeds with titles that have ampersands in them. I was having a problem with that. There are also tags for displaying how long ago a post was written and for customizing the way a post is truncated.
